### PR TITLE
Allow to redefine ASDF system for example server.

### DIFF
--- a/src/doc/example-server.lisp
+++ b/src/doc/example-server.lisp
@@ -391,4 +391,5 @@ pre {
     (start-server :port port
                   :debug debug
                   :interface interface
-                  :for-asdf-system "reblocks")))
+                  :for-asdf-system (or (uiop:getenv "ASDF_SYSTEM")
+                                        "reblocks"))))


### PR DESCRIPTION
Set ASDF_SYSTEM environment variable in Heroku server.