### PR TITLE
welcome screen not honors *welcome-screen-enabled*

### DIFF
--- a/src/default-init.lisp
+++ b/src/default-init.lisp
@@ -94,7 +94,8 @@
   )
 
 (defmethod reblocks/session:init ((app welcome-screen-app))
-  (make-instance 'welcome-screen-widget))
+  (when *welcome-screen-enabled*
+    (make-instance 'welcome-screen-widget)))
 
 ;; (when *welcome-screen-enabled*
 ;;   (reblocks/app:start 'welcome-screen-app))


### PR DESCRIPTION
The welcome screen should honors  *welcome-screen-enabled* parameter. 
Otherwise its started ervytime blocking other apps on root.