### PR TITLE
Fixed welcome page logic + many other fixes

### DIFF
--- a/reblocks.asd
+++ b/reblocks.asd
@@ -24,6 +24,7 @@
                "reblocks/commands-hook"
                "reblocks/widgets/string-widget"
                "reblocks/widgets/funcall-widget"
+               "reblocks/welcome/widget"
                "reblocks/utils/clos"
                "reblocks/utils/i18n"
                "reblocks/preview"

--- a/src/app-mop.lisp
+++ b/src/app-mop.lisp
@@ -1,7 +1,5 @@
 (uiop:define-package #:reblocks/app-mop
   (:use #:cl)
-  (:import-from #:alexandria
-                #:removef)
   (:import-from #:metatilities
                 #:removef)
   (:shadowing-import-from #:closer-mop

--- a/src/app-mop.lisp
+++ b/src/app-mop.lisp
@@ -1,5 +1,9 @@
 (uiop:define-package #:reblocks/app-mop
   (:use #:cl)
+  (:import-from #:alexandria
+                #:removef)
+  (:import-from #:metatilities
+                #:removef)
   (:shadowing-import-from #:closer-mop
                           #:standard-class
                           #:validate-superclass
@@ -46,9 +50,9 @@
     ;; (pushnew name (symbol-value '*registered-apps*))
     (pushnew name *registered-apps*)
     
-    (when autostart
-      ;; (pushnew name (symbol-value '*autostarting-apps*))
-      (pushnew name *autostarting-apps*))))
+    (if autostart
+        (pushnew name *autostarting-apps*)
+        (removef name *autostarting-apps*))))
 
 
 (defun get-registered-apps ()

--- a/src/app.lisp
+++ b/src/app.lisp
@@ -102,6 +102,7 @@ layout and dependencies running on the same server."))
                     subclasses
                     slots
                     description
+                    documentation
                     (autostart t)
                   &allow-other-keys)
   "This macro defines the key parameters for a stand alone web application.  
@@ -127,16 +128,25 @@ co-exist, so long as they have different prefixes
 
 DESCRIPTION - A description of the application for the title page
 
+DOCUMENTATION - Content of this argument will be added as (:documentation ...) form
+to the class definition.
+
 AUTOSTART - Whether this webapp is started automatically when start-reblocks is
 called (primarily for backward compatibility"
   (declare (ignore prefix description))
   
   (let ((default-initargs
           (remove-keyword-parameters initargs
-                                     :subclasses :slots :autostart)))
+                                     :subclasses
+                                     :slots
+                                     :autostart
+                                     :documentation))
+        (documentation (when documentation
+                         (list (list :documentation documentation)))))
     `(progn
        (defclass ,name (,@subclasses app)
          ,slots
+         ,@documentation
          (:autostart . ,autostart)
          (:default-initargs ,@default-initargs)
          (:metaclass app-class)))))

--- a/src/default-init.lisp
+++ b/src/default-init.lisp
@@ -20,12 +20,12 @@
                 #:with-html)
   (:import-from #:reblocks/app
                 #:*current-app*)
-  (:export #:welcome-screen-app))
+  (:import-from #:spinneret/cl-markdown))
 (in-package #:reblocks/default-init)
 
 
 (defmethod init ((app t))
-  (let ((quickstart-url "http://40ants.com/reblocks/quickstart.html"))
+  (let ((quickstart-url "http://40ants.com/reblocks/quickstart/"))
     (make-string-widget
      (with-html-string
        (:h1 "No reblocks/session:init method defined.")
@@ -33,11 +33,18 @@
        (:p "It could be something simple, like this one:")
        (:pre
         (:code
-         ("(defmethod reblocks/session:init ((app ~A))  
-            \"Hello world!\")" (string-downcase
-                                (type-of *current-app*)))))
+         (format nil "
+CL-USER> (defmethod reblocks/session:init ((app ~A))  
+           \"Hello world!\")" (string-downcase
+                               (type-of *current-app*)))))
+       (:p "And reset current session:")
+       (:pre
+        (:code
+         "
+CL-USER> (reblocks/debug:reset-latest-session)"))
 
-       (:p ("Read more in [documentaion]()."
+       (:p "Then reload the page.")
+       (:p ("Read more in [documentaion](~A)."
             quickstart-url)))
      :escape-p nil)))
 
@@ -49,52 +56,61 @@
   (let ((root (call-next-method)))
     (create-widget-from root)))
 
-(defapp welcome-screen-app
-    :prefix "/")
 
-(defparameter *welcome-screen-enabled* t
-  "If t, show the welcome screen on the root url, if no other widget use the path.")
+(defapp welcome-screen-app
+  :documentation "Idea of this app is to have some default application will be served on \"/\"
+                  prefix when there is no other app for \"/\" prefix is defined."
+  :prefix "/"
+  :autostart nil)
+
 
 (defwidget welcome-screen-widget ()
   ())
 
+
 (defmethod render ((widget welcome-screen-widget))
   ;; I have to comment out this code because app activity was refactored in the
   ;; latest version. We need to rethink this idea of a welcome screen.
-  ;; s
-  ;; (let ((apps (reblocks/app:get-active-apps)))
-  ;;   (with-html
-  ;;     (:h1 "Welcome to Reblocks!")
-  ;;     (:div "To learn more about Reblocks, head over its "
-  ;;           (:a :href "http://40ants.com/reblocks/" "documentation.")
-  ;;           " To learn how to create apps and widgets, see the "
-  ;;           (:a :href "http://40ants.com/reblocks/quickstart.html" "quickstart guide")
-  ;;           ".")
-  ;;     (:h3)
-  ;;     (when apps
-  ;;       (:div "You also have active apps, congratulations! You are running:")
-  ;;       (loop for app in apps
-  ;;             do
-  ;;                (let ((prefix (get-prefix app)))
-  ;;                  (:ul
-  ;;                   (:li
-  ;;                    (:a :href prefix (format nil "~a" (reblocks/app::webapp-name app)))
-  ;;                    (:span (format nil " on \"~a\"" prefix))))))
+  ;; 
+  (let ((apps (reblocks/server::apps reblocks/server::*server*)))
+    (with-html
+      (:h1 "Welcome to Reblocks!")
+      (:p ("To learn more about Reblocks, head over its [documentation](http://40ants.com/reblocks/)."))
+      (:p ("To learn how to create apps and widgets, see the [quickstart guide](http://40ants.com/reblocks/quickstart/)."))
+      (:h3)
+      (when apps
+        (:div "You have some apps, congratulations! Here they are:")
+        (:ul
+         (loop for app in apps
+               for prefix = (get-prefix app)
+               for app-name = (reblocks/app::webapp-name app)
+               do (:li
+                   (:a :href prefix (format nil "~A" app-name))
+                   (:span (format nil " on \"~A\"" prefix)))))
+        
+        (:h3)
+        ;; Just in case if this widget will be used in some
+        ;; other apps:
+        (when (typep *current-app* 'welcome-screen-app)
+          (:p "This is the welcome screen, a Reblocks app itself.")
+          (:p "If you want to disable this welcome screen, just define an application with \"/\" prefix:")
+          (:pre (:code "
+CL-USER> (reblocks/app:defapp my-app
+           :prefix \"/\")"))
+          (:h3)
+          (:p "And then restart the server like this:")
+          (let* ((server reblocks/server::*server*)
+                 (interface (reblocks/server::get-interface server))
+                 (port (reblocks/server::get-port server)))
+            (:pre (:code (format nil "
+CL-USER> (reblocks/server:stop ~S ~S)
 
-  ;;       (:h3)
-  ;;       (when (app-active-p 'welcome-screen-app)
-  ;;         (:div "This is the welcome screen, a Reblocks app itself.")
-  ;;         (:div "If you want to stop it, do:")
-  ;;         (:code "(reblocks/app:stop 'reblocks/default-init:welcome-screen-app)")
-  ;;         (:div "And in case you want to disable it before the server starts, do:")
-  ;;         (:code "(setf reblocks/default-init::*welcome-screen-enabled* nil)")
-  ;;         (:h3)
-  ;;         (:div "If you want to bind your app to \"/\", use the prefix argument of defapp:")
-  ;;         (:code "(defapp myapp :prefix \"/\")")))))
-  )
+CL-USER> (reblocks/server:start :interface ~S
+                                :port ~S)
+"
+                                 interface port
+                                 interface port)))))))))
+
 
 (defmethod reblocks/session:init ((app welcome-screen-app))
   (make-instance 'welcome-screen-widget))
-
-;; (when *welcome-screen-enabled*
-;;   (reblocks/app:start 'welcome-screen-app))

--- a/src/default-init.lisp
+++ b/src/default-init.lisp
@@ -4,9 +4,6 @@
                 #:get-prefix
                 #:webapp-name
                 #:defapp)
-  (:import-from #:reblocks/widget
-                #:render
-                #:defwidget)
   (:import-from #:reblocks/session
                 #:init)
   (:import-from #:reblocks/widget
@@ -16,8 +13,6 @@
                 #:with-html-string)
   (:import-from #:reblocks/widgets/string-widget
                 #:make-string-widget)
-  (:import-from #:reblocks/html
-                #:with-html)
   (:import-from #:reblocks/app
                 #:*current-app*)
   (:import-from #:spinneret/cl-markdown))
@@ -55,62 +50,3 @@ CL-USER> (reblocks/debug:reset-latest-session)"))
 
   (let ((root (call-next-method)))
     (create-widget-from root)))
-
-
-(defapp welcome-screen-app
-  :documentation "Idea of this app is to have some default application will be served on \"/\"
-                  prefix when there is no other app for \"/\" prefix is defined."
-  :prefix "/"
-  :autostart nil)
-
-
-(defwidget welcome-screen-widget ()
-  ())
-
-
-(defmethod render ((widget welcome-screen-widget))
-  ;; I have to comment out this code because app activity was refactored in the
-  ;; latest version. We need to rethink this idea of a welcome screen.
-  ;; 
-  (let ((apps (reblocks/server::apps reblocks/server::*server*)))
-    (with-html
-      (:h1 "Welcome to Reblocks!")
-      (:p ("To learn more about Reblocks, head over its [documentation](http://40ants.com/reblocks/)."))
-      (:p ("To learn how to create apps and widgets, see the [quickstart guide](http://40ants.com/reblocks/quickstart/)."))
-      (:h3)
-      (when apps
-        (:div "You have some apps, congratulations! Here they are:")
-        (:ul
-         (loop for app in apps
-               for prefix = (get-prefix app)
-               for app-name = (reblocks/app::webapp-name app)
-               do (:li
-                   (:a :href prefix (format nil "~A" app-name))
-                   (:span (format nil " on \"~A\"" prefix)))))
-        
-        (:h3)
-        ;; Just in case if this widget will be used in some
-        ;; other apps:
-        (when (typep *current-app* 'welcome-screen-app)
-          (:p "This is the welcome screen, a Reblocks app itself.")
-          (:p "If you want to disable this welcome screen, just define an application with \"/\" prefix:")
-          (:pre (:code "
-CL-USER> (reblocks/app:defapp my-app
-           :prefix \"/\")"))
-          (:h3)
-          (:p "And then restart the server like this:")
-          (let* ((server reblocks/server::*server*)
-                 (interface (reblocks/server::get-interface server))
-                 (port (reblocks/server::get-port server)))
-            (:pre (:code (format nil "
-CL-USER> (reblocks/server:stop ~S ~S)
-
-CL-USER> (reblocks/server:start :interface ~S
-                                :port ~S)
-"
-                                 interface port
-                                 interface port)))))))))
-
-
-(defmethod reblocks/session:init ((app welcome-screen-app))
-  (make-instance 'welcome-screen-widget))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -27,6 +27,28 @@
                                                    "CSS"
                                                    "HTTP")
                                     :external-links (("Ultralisp" . "https://ultralisp.org")))
+  (0.44.0 2022-02-09
+          """
+Fixed
+=====
+
+* Fixed the way how welcome page app is started. Now it always started unless some
+  other application does not use "/" prefix.
+* Also, fixed the way how application is choosen depending on request url path.
+* Function REBLOCKS/SERVER:STOP now removes all application and routes from the
+  server instance. This way when you'll start it again, server might serve another
+  set of the applications.
+* Now if you redefine your app using REBLOCKS/APP:DEFAPP macro and change
+  AUTOSTART argument from `T` to NIL, this app will be removed from the list
+  of applications to autostart.
+
+Added
+=====
+
+* Now macro REBLOCKS/APP:DEFAPP supports DOCUMENTATION argument. Use it to add documentation
+  to application's class.
+
+""")
   (0.43.0 2022-02-07
           """
 Changed

--- a/src/hooks.lisp
+++ b/src/hooks.lisp
@@ -9,6 +9,7 @@
                 #:symbolicate
                 #:ensure-symbol
                 #:with-gensyms)
+  (:import-from #:40ants-doc)
   (:import-from #:40ants-doc/ignored-words
                 #:ignore-words-in-package)
   

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -38,7 +38,7 @@
   ;; Just dependencies
   (:import-from #:reblocks/debug)
   (:import-from #:log)
-  (:import-from #:reblocks/default-init
+  (:import-from #:reblocks/welcome/app
                 #:welcome-screen-app)
   (:import-from #:alexandria
                 #:compose)

--- a/src/welcome/app.lisp
+++ b/src/welcome/app.lisp
@@ -1,0 +1,12 @@
+(uiop:define-package #:reblocks/welcome/app
+  (:use #:cl)
+  (:import-from #:reblocks/app
+                #:defapp))
+(in-package #:reblocks/welcome/app)
+
+
+(defapp welcome-screen-app
+  :documentation "Idea of this app is to have some default application will be served on \"/\"
+                  prefix when there is no other app for \"/\" prefix is defined."
+  :prefix "/"
+  :autostart nil)

--- a/src/welcome/widget.lisp
+++ b/src/welcome/widget.lisp
@@ -1,0 +1,70 @@
+(uiop:define-package #:reblocks/welcome/widget
+  (:use #:cl)
+  (:import-from #:reblocks/server
+                #:get-port
+                #:get-interface)
+  (:import-from #:reblocks/session)
+  (:import-from #:reblocks/html
+                #:with-html)
+  (:import-from #:reblocks/widget
+                #:render
+                #:defwidget)
+  (:import-from #:reblocks/welcome/app
+                #:welcome-screen-app)
+  (:import-from #:reblocks/app
+                #:get-prefix
+                #:webapp-name
+                #:*current-app*))
+(in-package #:reblocks/welcome/widget)
+
+
+(defwidget welcome-screen-widget ()
+  ())
+
+
+(defmethod reblocks/session:init ((app welcome-screen-app))
+  (make-instance 'welcome-screen-widget))
+
+
+(defmethod render ((widget welcome-screen-widget))
+  ;; I have to comment out this code because app activity was refactored in the
+  ;; latest version. We need to rethink this idea of a welcome screen.
+  ;; 
+  (let ((apps (reblocks/server::apps reblocks/server::*server*)))
+    (with-html
+      (:h1 "Welcome to Reblocks!")
+      (:p ("To learn more about Reblocks, head over its [documentation](http://40ants.com/reblocks/)."))
+      (:p ("To learn how to create apps and widgets, see the [quickstart guide](http://40ants.com/reblocks/quickstart/)."))
+      (:h3)
+      (when apps
+        (:div "You have some apps, congratulations! Here they are:")
+        (:ul
+         (loop for app in apps
+               for prefix = (get-prefix app)
+               for app-name = (webapp-name app)
+               do (:li
+                   (:a :href prefix (format nil "~A" app-name))
+                   (:span (format nil " on \"~A\"" prefix)))))
+        
+        (:h3)
+        ;; Just in case if this widget will be used in some
+        ;; other apps:
+        (when (typep *current-app* 'welcome-screen-app)
+          (:p "This is the welcome screen, a Reblocks app itself.")
+          (:p "If you want to disable this welcome screen, just define an application with \"/\" prefix:")
+          (:pre (:code "
+CL-USER> (reblocks/app:defapp my-app
+           :prefix \"/\")"))
+          (:h3)
+          (:p "And then restart the server like this:")
+          (let* ((server reblocks/server::*server*)
+                 (interface (get-interface server))
+                 (port (get-port server)))
+            (:pre (:code (format nil "
+CL-USER> (reblocks/server:stop ~S ~S)
+
+CL-USER> (reblocks/server:start :interface ~S
+                                :port ~S)
+"
+                                 interface port
+                                 interface port)))))))))


### PR DESCRIPTION
Fixed
=====

* Fixed the way how welcome page app is started. Now it always started unless some
  other application does not use "/" prefix.
* Also, fixed the way how application is choosen depending on request url path.
* Function REBLOCKS/SERVER:STOP now removes all application and routes from the
  server instance. This way when you'll start it again, server might serve another
  set of the applications.
* Now if you redefine your app using REBLOCKS/APP:DEFAPP macro and change
  AUTOSTART argument from `T` to NIL, this app will be removed from the list
  of applications to autostart.

Added
=====

* Now macro REBLOCKS/APP:DEFAPP supports DOCUMENTATION argument. Use it to add documentation
  to application's class.