### PR TITLE
Interactive demos now are rendered just as code block into markdown documents

### DIFF
--- a/reblocks.asd
+++ b/reblocks.asd
@@ -14,7 +14,7 @@
   :author "Alexander Artemenko"
   :licence "LLGPL"
   :description "A Common Lisp web framework, successor of the Weblocks."
-  :homepage "https://40ants.com/reblocks"
+  :homepage "https://40ants.com/reblocks/"
   :source-control (:git "https://github.com/40ants/reblocks")
   :pathname "src"
   :depends-on ("40ants-doc"

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -27,6 +27,15 @@
                                                    "CSS"
                                                    "HTTP")
                                     :external-links (("Ultralisp" . "https://ultralisp.org")))
+  (0.45.0 2022-02-14
+          """
+Changed
+=======
+
+* Interactive demos now are rendered just as code block into markdown documents.
+  Such code block is followed by a link to HTML documentation if ASDF system
+  defines a `homepage`.
+""")
   (0.44.0 2022-02-09
           """
 Fixed

--- a/src/doc/example-server.lisp
+++ b/src/doc/example-server.lisp
@@ -240,18 +240,8 @@ pre {
                       (:code :class "language-lisp"
                              ;; :onload "alert('Herel')"
                              ;; :onload "hljs.highlightElement(this)"
-                             (let* ((example (current-example widget))
-                                    (*package* (example-package example)))
-                               (with-output-to-string (s)
-                                 (loop for form in (example-body example)
-                                       do (write form
-                                                 :stream s
-                                                 :case :downcase
-                                                 :readably t)
-                                          (terpri s)
-                                          (terpri s)))))))))
-
-       )
+                             (reblocks/doc/example::example-code
+                              (current-example widget))))))))
       (t
        (with-html
          (:h1 ("No widget with path ~A" path))

--- a/src/doc/example.lisp
+++ b/src/doc/example.lisp
@@ -9,12 +9,18 @@
                 #:with-html)
   (:import-from #:alexandria
                 #:hash-table-keys)
-  (:import-from #:serapeum)
+  (:import-from #:serapeum
+                #:->)
   (:import-from #:40ants-doc/commondoc/builder)
   (:import-from #:reblocks/hooks
                 #:defhook)
   (:import-from #:global-vars
                 #:define-global-var)
+  (:import-from #:40ants-doc/reference-api
+                #:canonical-reference)
+  (:import-from #:40ants-doc/ignored-words
+                #:supports-ignored-words-p
+                #:ignore-words-in-package)
   (:export #:defexample
            #:reblocks-example
            #:start-server
@@ -40,7 +46,8 @@
    (height :initarg :height
            :reader example-height)
    (package :initarg :package
-            :reader example-package)
+            :reader example-package
+            :documentation "This slot will contain a package, created for especially this example's body.")
    (original-body :initarg :original-body
                   :type cons
                   :reader example-original-body
@@ -67,11 +74,42 @@
   (symbol-value symbol))
 
 
+(defmethod canonical-reference ((example reblocks-example))
+  (40ants-doc/reference:make-reference (example-name example)
+                                       '40ants-doc/locatives::reblocks-example))
+
+
 (define-global-var *iframe-id* 0)
 
 
+(defclass example-block (40ants-doc/commondoc/piece::documentation-piece
+                         common-doc:document-node)
+  ((example :initarg :example :reader example)))
+
+
 (defmethod 40ants-doc/commondoc/builder:to-commondoc ((example reblocks-example))
-  (let* ((iframe-id (format nil "example-~A"
+  (make-instance 'example-block
+                 :example example
+                 :doc-reference (40ants-doc/reference-api:canonical-reference example)))
+
+
+(defmethod common-doc.format:emit-document ((format commondoc-markdown:markdown)
+                                            (node  example-block)
+                                            stream)
+
+  ;; TODO: here we may need to use current indentation
+  ;; in case if this piece of code is nested inside in a list.
+  ;; But for now it should work without an indentation.
+  (format stream "~2&```lisp~&~A~&```~2&"
+          (example-code (example node)))
+  (when 40ants-doc/builder/vars::*base-url*
+    (format stream "~2&Go to [HTML documentation](~A) to see this code in action.~2&"
+            40ants-doc/builder/vars::*base-url*)))
+
+
+(common-html.emitter::define-emitter (obj example-block)
+  (let* ((example (example obj))
+         (iframe-id (format nil "example-~A"
                             (incf *iframe-id*)))
          (full-url (format nil "~A~A?iframe-id=~A"
                            (or *server-url*
@@ -86,23 +124,29 @@ window.addEventListener('message', function(e) {
   let message = e.data;
   let iframe_id = message.iframe_id;
   let iframe = document.querySelector('#' + iframe_id);
-  iframe.style.height = message.height + 'px';
-  iframe.style.width = message.width + 'px';
+  if (iframe) {
+    iframe.style.height = message.height + 'px';
+    iframe.style.width = message.width + 'px';
+  } else {
+    console.log('Unable to find iframe with id', iframe_id);
+  }
 } , false);
-"))
-    (commondoc-markdown/raw-html:make-raw-html-block
-     (reblocks/html:with-html-string
-       (:div :class "demo"
-             (:iframe :id iframe-id
-                      :src full-url
-                      :sandbox "allow-forms allow-same-origin allow-scripts"
-                      :style (format nil "width: ~A; height: ~A; border: 0"
-                                     (example-width example)
-                                     (example-height example))))
-       (:script
-        ;; TODO: remove :RAW after this issue will be solved:
-        ;; https://github.com/ruricolist/spinneret/issues/59
-        (:raw js-code))))))
+")
+         (html (reblocks/html:with-html-string
+                 (:div :class "demo"
+                       (:iframe :id iframe-id
+                                :src full-url
+                                :sandbox "allow-forms allow-same-origin allow-scripts"
+                                :style (format nil "width: ~A; height: ~A; border: 0"
+                                               (example-width example)
+                                               (example-height example))))
+                 (:script
+                  ;; TODO: remove :RAW after this issue will be solved:
+                  ;; https://github.com/ruricolist/spinneret/issues/59
+                  (:raw js-code)))))
+
+    (write-string html
+                  common-html.emitter::*output-stream*)))
 
 
 (defun replace-internal-symbols (body &key from-package to-package)
@@ -170,6 +214,11 @@ window.addEventListener('message', function(e) {
                                         :height ,height
                                         :original-body ',full-body
                                         :body new-body)))
+           ;; Here we are registering a symbol
+           ;; to prevent 40ANTS-DOC's complains.
+           (let ((*package* package))
+             (ignore-words-in-package ',name))
+
            (register example)
            (values example))))))
 
@@ -179,6 +228,20 @@ window.addEventListener('message', function(e) {
     (format nil "/~A/~A"
             (string-downcase (package-name (symbol-package name)))
             (string-downcase (symbol-name name)))))
+
+(-> example-code (reblocks-example) string)
+(defun example-code (example)
+  "Returns example's code as a string."
+  
+  (let ((*package* (example-package example)))
+    (with-output-to-string (s)
+      (loop for form in (example-body example)
+            do (write form
+                      :stream s
+                      :case :downcase
+                      :readably t)
+               (terpri s)
+               (terpri s)))))
 
 
 


### PR DESCRIPTION
Such code block is followed by a link to HTML documentation if ASDF system
defines a `homepage`.