### PR TITLE
Fixed the way how dependencies are rendered in AJAX action response.

### DIFF
--- a/src/commands-hook.lisp
+++ b/src/commands-hook.lisp
@@ -1,4 +1,4 @@
-(defpackage #:reblocks/commands-hook
+(uiop:define-package #:reblocks/commands-hook
   (:use #:cl)
   (:import-from #:reblocks/hooks
                 #:on-application-hook-handle-http-request

--- a/src/commands.lisp
+++ b/src/commands.lisp
@@ -7,11 +7,13 @@
 (in-package #:reblocks/commands)
 
 
-(defvar *commands* nil
-  "A list of commands to execute on a client as a result of action call.
+(defvar *commands*)
 
-These commands are collected during action processing and rendered to resulting JSON
-as some sort of JSON-rpc calls to be esecuted on a client-side.")
+(setf (documentation '*commands* 'variable)
+      "A list of commands to execute on a client as a result of action call.
+
+       These commands are collected during action processing and rendered to resulting JSON
+       as some sort of JSON-rpc calls to be esecuted on a client-side.")
 
 
 (defun cl-symbol-to-js-symbol (symbol)

--- a/src/dependencies.lisp
+++ b/src/dependencies.lisp
@@ -205,18 +205,17 @@ as a response to some action.")
 
 
 (defmethod render-in-ajax-response ((dependency dependency))
-  (case (get-type dependency)
-    (:js
-     (let ((script (parenscript:ps* `(include_dom
-                                      ,(get-url dependency)))))
-       (log:debug "Rendering js dependency in ajax response" dependency)
-       (send-script script :before-load)))
+  (let ((url (get-url dependency)))
+    (case (get-type dependency)
+      (:js
+       (let ((script (parenscript:ps* `(include_dom ,url))))
+         (log:debug "Rendering js dependency in ajax response" dependency)
+         (send-script script :before-load)))
 
-    (:css
-     (let ((script (parenscript:ps* `(include_css
-                                      ,(get-url dependency)))))
-       (log:debug "Rendering css dependency in ajax response" dependency)
-       (send-script script :before-load)))))
+      (:css
+       (let ((script (parenscript:ps* `(include_css ,url))))
+         (log:debug "Rendering css dependency in ajax response" dependency)
+         (send-script script :before-load))))))
 
 
 (defmethod render-in-head ((dependency remote-dependency))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -27,6 +27,16 @@
                                                    "CSS"
                                                    "HTTP")
                                     :external-links (("Ultralisp" . "https://ultralisp.org")))
+
+  (0.45.1 2022-06-02
+          """
+Fixed
+=====
+
+* Fixed the way how dependencies are rendered in AJAX action response. Previously,
+  when many widgets of the same class were updated on one user action Reblocks sent
+  a duplicate css/js dependencies.
+""")
   (0.45.0 2022-02-14
           """
 Changed

--- a/src/request-handler.lisp
+++ b/src/request-handler.lisp
@@ -177,13 +177,20 @@ customize behavior."))
 (defmethod handle-ajax-request ((app app))
   (log:debug "Handling AJAX request")
   
-  (write
-   (to-json
-    (list :|commands| (get-collected-commands)))
-   ;; Seems like a hack, because we have to know implementation details of reblocks/html here.
-   ;; TODO: hide implementation details.
-   :stream *stream*
-   :escape nil))
+  ;; Generate code to embed new dependencies into the page on the fly.
+  ;; This render will generate commands to include necessary pieces
+  ;; of JS and CSS into the page.
+  (mapc #'reblocks/dependencies:render-in-ajax-response
+        reblocks/dependencies::*page-dependencies*)
+  
+  (let ((commands (get-collected-commands)))
+    (write
+     (to-json
+      (list :|commands| commands))
+     ;; Seems like a hack, because we have to know implementation details of reblocks/html here.
+     ;; TODO: hide implementation details.
+     :stream *stream*
+     :escape nil)))
 
 
 (defmethod handle-normal-request ((app app))

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -42,8 +42,9 @@
 (in-package #:reblocks/request)
 
 
-(defvar *request* nil
-  "Holds current request from a browser.")
+(defvar *request*)
+(setf (documentation '*request* 'variable)
+      "Holds current request from a browser.")
 
 
 (defun get-uri (&key (request *request*))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -147,7 +147,16 @@ This function serves all started applications and their static files."
         (prepare-hooks
           (reblocks/hooks:with-handle-http-request-hook (env)
 
-            (let* ((path-info (getf env :path-info))
+            (let* ((path-info (getf env
+                                    ;; Previously, we used :path-info
+                                    ;; attribute here, but it has %20 replaced
+                                    ;; with white-spaces and get-route breaks
+                                    ;; on URIs having spaces, because it calls
+                                    ;; cl-routes and it calls puri:parse-uri
+                                    ;; which requires URI to be url-encoded.
+                                    ;; Hope, this change will not break other
+                                    ;; places where PATH-INFO is used.
+                                    :request-uri))
                    (hostname (getf env :server-name))
                    (route (get-route path-info))
                    (app (search-app-for-request-handling path-info hostname)))

--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -39,12 +39,7 @@
   
   (let ((widget-dependencies (get-dependencies widget)))
     ;; Update new-style dependencies
-    (push-dependencies widget-dependencies)
-    
-    (when (ajax-request-p)
-      ;; Generate code to embed new dependencies into the page on the fly
-      (mapc #'render-in-ajax-response
-            widget-dependencies)))
+    (push-dependencies widget-dependencies))
   
   (with-html
     (:tag


### PR DESCRIPTION
Previously, when many widgets of the same class were updated on one user action Reblocks sent a duplicate css/js dependencies.