### PR TITLE
Error page rendering was fixed.

### DIFF
--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -30,6 +30,14 @@
                                                    "REBLOCKS/ERROR-HANDLER")
                                     :external-links (("Ultralisp" . "https://ultralisp.org"))
                                     :external-docs ("https://40ants.com/log4cl-extras/"))
+  (0.46.1 2022-09-16
+          """
+Fixed
+=====
+
+* Error page rendering was fixed. Now such variables as page description, tags and title are
+  bound to their defaults while calling REBLOCKS/ERROR-HANDLER:ON-ERROR generic-function.
+""")
   (0.46.0 2022-07-03
           """
 Changed

--- a/src/error-handler.lisp
+++ b/src/error-handler.lisp
@@ -14,6 +14,8 @@
                 #:with-gensyms)
   (:import-from #:reblocks/html
                 #:with-html-string)
+  (:import-from #:reblocks/page
+                #:with-page-defaults)
   
   (:export #:on-error))
 (in-package #:reblocks/error-handler)
@@ -44,36 +46,41 @@
                         :code 500)))
 
 
+(defun call-with-handled-errors (body-func)
+  (let ((debugger-was-invoked-on-cond nil)
+        (backtrace nil))
+    ;; We need to have this handler-bind block a separate from the inner one,
+    ;; because when (on-error) call happens, bindings from the inner handler-bind
+    ;; aren't available, but we need to catch an immediate-response condition
+    (handler-bind ((immediate-response (lambda (condition)
+                                         (return-from call-with-handled-errors
+                                           (get-response condition))))
+                   (error (lambda (condition)
+                            (setf backtrace
+                                  (print-backtrace :condition condition
+                                                   :stream nil))
+                            (cond (*invoke-debugger-on-error*
+                                   (log:warn "Invoking interactive debugger because Reblocks is in the debug mode")
+                                   (setf debugger-was-invoked-on-cond
+                                         condition)
+                                   (invoke-debugger condition))
+                                  (t
+                                   (log:warn "Returning error because Reblocks is not in the debug mode")
+                                   (with-page-defaults
+                                     (on-error *current-app*
+                                               condition
+                                               :backtrace backtrace)))))))
+      (restart-case
+          (funcall body-func)
+        (abort ()
+          :report "Abort request processing and return 500."
+          (log:warn "Aborting request processing")
+          (with-page-defaults
+            (on-error *current-app*
+                      debugger-was-invoked-on-cond
+                      :backtrace backtrace)))))))
+
+
 (defmacro with-handled-errors (&body body)
-  (with-gensyms (block-name)
-    `(block ,block-name
-       (let ((debugger-was-invoked-on-cond nil)
-             (backtrace nil))
-         ;; We need to have this handler-bind block a separate from the inner one,
-         ;; because when (on-error) call happens, bindings from the inner handler-bind
-         ;; aren't available, but we need to catch an immediate-response condition
-         (handler-bind ((immediate-response (lambda (condition)
-                                              (return-from ,block-name
-                                                (get-response condition))))
-                        (error (lambda (condition)
-                                 (setf backtrace
-                                       (print-backtrace :condition condition
-                                                        :stream nil))
-                                 (cond (*invoke-debugger-on-error*
-                                        (log:warn "Invoking interactive debugger because Reblocks is in the debug mode")
-                                        (setf debugger-was-invoked-on-cond
-                                              condition)
-                                        (invoke-debugger condition))
-                                       (t
-                                        (log:warn "Returning error because Reblocks is not in the debug mode")
-                                        (on-error *current-app*
-                                                  condition
-                                                  :backtrace backtrace))))))
-           (restart-case
-               (progn ,@body)
-             (abort ()
-               :report "Abort request processing and return 500."
-               (log:warn "Aborting request processing")
-               (on-error *current-app*
-                         debugger-was-invoked-on-cond
-                         :backtrace backtrace))))))))
+  `(call-with-handled-errors (lambda ()
+                               ,@body)))

--- a/src/page.lisp
+++ b/src/page.lisp
@@ -144,12 +144,17 @@
         )))))
 
 
+(defun call-with-page-defaults (body-func)
+  (let ((*title* nil)
+        (*description* nil)
+        (*keywords* nil)
+        (*language* *default-language*))
+    (funcall body-func)))
+
+
 (defmacro with-page-defaults (&body body)
-  `(let ((*title* nil)
-         (*description* nil)
-         (*keywords* nil)
-         (*language* *default-language*))
-     ,@body))
+  `(call-with-page-defaults
+    (lambda () ,@body)))
 
 
 (defmethod render-page-with-widgets ((app app))

--- a/src/routes-error-handler.lisp
+++ b/src/routes-error-handler.lisp
@@ -1,0 +1,14 @@
+(uiop:define-package #:reblocks/routes-error-handler
+  (:use #:cl)
+  (:import-from #:reblocks/error-handler
+                #:with-handled-errors)
+  (:import-from #:reblocks/routes
+                #:serve))
+(in-package #:reblocks/routes-error-handler)
+
+
+(defmethod serve :around (route env)
+  "This method handles unhandled exceptions, because this code is common for all routes."
+  (with-handled-errors
+    (call-next-method)))
+

--- a/src/routes.lisp
+++ b/src/routes.lisp
@@ -1,8 +1,6 @@
 (uiop:define-package #:reblocks/routes
   (:use #:cl)
   (:import-from #:routes)
-  (:import-from #:reblocks/error-handler
-                #:with-handled-errors)
   (:export #:route
            #:serve
            #:get-route
@@ -77,12 +75,6 @@
         (t (list 400
                  (list :content-type "text/plain")
                  "No handler for this route"))))))
-
-
-(defmethod serve :around (route env)
-  "This method handles unhandled exceptions, because this code is common for all routes."
-  (with-handled-errors
-    (call-next-method)))
 
 
 (defmacro defroute ((app route &key (content-type "application/json")) &body body)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -13,6 +13,7 @@
                 #:get-route
                 #:add-route
                 #:add-routes)
+  (:import-from #:reblocks/routes-error-handler)
   (:import-from #:reblocks/app
                 #:get-prefix
                 #:app-serves-hostname-p


### PR DESCRIPTION
Now such variables as page description, tags and title are bound to their defaults while calling REBLOCKS/ERROR-HANDLER:ON-ERROR generic-function.