### PR TITLE
Now Reblocks remembers which dependencies are already loaded into the page and will not fetch them again.

### DIFF
--- a/src/dependencies.lisp
+++ b/src/dependencies.lisp
@@ -565,4 +565,6 @@ Makes deduplication by comparing dependencies' urls."
 
   ;; Dependencies returned as reversed list because that way
   ;; they will have same order as they were pushed.
-  (reverse *page-dependencies*))
+  (remove-duplicates (reverse *page-dependencies*)
+                     :key #'get-url
+                     :test #'string-equal))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -30,6 +30,15 @@
                                                    "REBLOCKS/ERROR-HANDLER")
                                     :external-links (("Ultralisp" . "https://ultralisp.org"))
                                     :external-docs ("https://40ants.com/log4cl-extras/"))
+  (0.48.0 2022-11-07
+          """
+Fixed
+=====
+
+Now Reblocks remembers which dependencies are already loaded into the page and
+will not fetch them again. This fixes issue when it fetched jQuery and broke
+it's extensions making further action calls made via GET instead of Ajax.
+""")
   (0.47.0 2022-11-04
           """
 Added

--- a/src/js/jquery/jquery.js
+++ b/src/js/jquery/jquery.js
@@ -394,13 +394,16 @@ function include_css(css_file) {
 }
 
 function include_dom(script_filename) {
-  var html_doc = document.getElementsByTagName('head').item(0);
-  var js = document.createElement('script');
-  js.setAttribute('language', 'javascript');
-  js.setAttribute('type', 'text/javascript');
-  js.setAttribute('src', script_filename);
-  html_doc.appendChild(js);
-  return false;
+    if (!window.loadedDependencies.includes(script_filename)) {
+        var html_doc = document.getElementsByTagName('head').item(0);
+        var js = document.createElement('script');
+        js.setAttribute('language', 'javascript');
+        js.setAttribute('type', 'text/javascript');
+        js.setAttribute('src', script_filename);
+        html_doc.appendChild(js);
+        window.loadedDependencies.push(script_filename);
+    }
+    return false;
 }
 
 /* working with CSS classes */

--- a/src/page.lisp
+++ b/src/page.lisp
@@ -1,5 +1,6 @@
 (uiop:define-package #:reblocks/page
   (:use #:cl)
+  (:import-from #:parenscript)
   (:import-from #:reblocks/variables
                 #:*default-content-type*)
   (:import-from #:reblocks/html
@@ -123,7 +124,10 @@
 
   (register-dependencies dependencies)
 
-  (let ((*lang* (get-language)))
+  (let ((*lang* (get-language))
+        (deps-urls (when (typep dependencies 'list)
+                     (mapcar #'reblocks/dependencies:get-url
+                             dependencies))))
     (with-html
       (:doctype)
       (:html
@@ -136,7 +140,10 @@
                :content "width=device-width, initial-scale=1")
               
         (render-headers app)
-        (render-dependencies app dependencies))
+        (render-dependencies app dependencies)
+        (:script (:raw
+                  (ps:ps* `(setf (ps:@ window loaded-dependencies)
+                                 (list ,@deps-urls))))))
        (:body
         (render-body app inner-html)
         ;; (:script :type "text/javascript"

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -133,10 +133,9 @@
   "Returns value of the cookie or nil. Name is case insensitive string."
   (check-type name string)
   
-  (loop with cookies = (request-cookies request)
-        for (key value) on cookies by #'cddr
-        when (string-equal key name)
-          do (return-from get-cookie value)))
+  (assoc-value (request-cookies request)
+               name
+               :test #'string-equal))
 
 
 (defun remove-header (name &key (request *request*))


### PR DESCRIPTION
This fixes issue when it fetched jQuery and broke it's extensions making further action calls made via GET instead of Ajax.