### PR TITLE
New functional was added which allows to control how does HTTP middle…

### DIFF
--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,8 +1,8 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2021-12-30"))
+  :version "2022-11-07"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20220206100500"))
+  :version "20221126111500"))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -30,6 +30,16 @@
                                                    "REBLOCKS/ERROR-HANDLER")
                                     :external-links (("Ultralisp" . "https://ultralisp.org"))
                                     :external-docs ("https://40ants.com/log4cl-extras/"))
+  (0.49.0 2022-11-26
+          """
+New functional was added which allows to control how does HTTP middlewares list is generated for the server.
+You might define your own REBLOCKS/SERVER:SERVER class and a method for REBLOCKS/SERVER:MAKE-MIDDLEWARES generic-function.
+Inside this method, you might inject additional middlewares using REBLOCKS/SERVER:INSERT-MIDDLEWARE function.
+
+Also, a variable REBLOCKS/SERVER:*DEFAULT-SAMESITE-POLICY* was introdiced, to control default value of the SameSite HTTP header.
+
+As a bonus, loading of reblocks-docs system was fixed.
+""")
   (0.48.0 2022-11-07
           """
 Fixed

--- a/src/doc/components.lisp
+++ b/src/doc/components.lisp
@@ -13,6 +13,10 @@
                                         "URI"
                                         "HTML"
                                         "CLOS"
+                                        "HTTP"
+                                        "LAYER"
+                                        "API"
+                                        "URL"
                                         "TCP"
                                         "MAKE-WIDGET"
                                         ;; TODO: make an external-link
@@ -102,12 +106,19 @@ To make everything work, you need to start one or more webservers on some TCP po
 When you are starting a server, usually you specify an interface and port to listen on
 and a list os Reblocks apps to serve.
 
+You might define your own server class and inherit it from REBLOCKS/SERVER:SERVER class.
+This will allow to customize a list of HTTP middlewares.
+
 Here is the list of functions useful when working with Reblocks servers:
 "
+  (reblocks/server:server class)
   (reblocks/server:start function)
   (reblocks/server:stop function)
   (reblocks/server:servers function)
   (reblocks/server:running-p function)
   (reblocks/server:serve-static-file generic-function)
   (reblocks/preview:preview function)
-  (reblocks/preview:stop function))
+  (reblocks/preview:stop function)
+  (reblocks/server:insert-middleware function)
+  (reblocks/server:make-middlewares generic-function)
+  (reblocks/server:*default-samesite-policy* variable))

--- a/src/doc/example.lisp
+++ b/src/doc/example.lisp
@@ -11,7 +11,8 @@
                 #:hash-table-keys)
   (:import-from #:serapeum
                 #:->)
-  (:import-from #:40ants-doc/commondoc/builder)
+  (:import-from #:40ants-doc-full/commondoc/builder
+                #:to-commondoc)
   (:import-from #:reblocks/hooks
                 #:defhook)
   (:import-from #:global-vars
@@ -21,6 +22,12 @@
   (:import-from #:40ants-doc/ignored-words
                 #:supports-ignored-words-p
                 #:ignore-words-in-package)
+  (:import-from #:40ants-doc-full/commondoc/piece
+                #:documentation-piece)
+  (:import-from #:40ants-doc-full/builder/vars
+                #:*base-url*)
+  (:import-from #:40ants-doc-full/utils
+                #:is-external)
   (:export #:defexample
            #:reblocks-example
            #:start-server
@@ -82,12 +89,12 @@
 (define-global-var *iframe-id* 0)
 
 
-(defclass example-block (40ants-doc/commondoc/piece::documentation-piece
+(defclass example-block (documentation-piece
                          common-doc:document-node)
   ((example :initarg :example :reader example)))
 
 
-(defmethod 40ants-doc/commondoc/builder:to-commondoc ((example reblocks-example))
+(defmethod to-commondoc ((example reblocks-example))
   (make-instance 'example-block
                  :example example
                  :doc-reference (40ants-doc/reference-api:canonical-reference example)))
@@ -102,9 +109,9 @@
   ;; But for now it should work without an indentation.
   (format stream "~2&```lisp~&~A~&```~2&"
           (example-code (example node)))
-  (when 40ants-doc/builder/vars::*base-url*
+  (when *base-url*
     (format stream "~2&Go to [HTML documentation](~A) to see this code in action.~2&"
-            40ants-doc/builder/vars::*base-url*)))
+            *base-url*)))
 
 
 (common-html.emitter::define-emitter (obj example-block)
@@ -160,7 +167,7 @@ window.addEventListener('message', function(e) {
                          (symbol (cond
                                    ((and (eql (symbol-package item)
                                               from-package)
-                                         (not (40ants-doc/utils:is-external item from-package)))
+                                         (not (is-external item from-package)))
                                     (intern (symbol-name item)
                                             to-package))
                                    (t

--- a/src/doc/hooks.lisp
+++ b/src/doc/hooks.lisp
@@ -14,7 +14,13 @@
                 #:defhook)
   (:import-from #:alexandria
                 #:ensure-symbol
-                #:symbolicate))
+                #:symbolicate)
+  (:import-from #:40ants-doc-full/commondoc/builder
+                #:reference-to-commondoc)
+  (:import-from #:40ants-doc-full/commondoc/markdown
+                #:parse-markdown)
+  (:import-from #:40ants-doc-full/commondoc/bullet
+                #:make-bullet))
 (in-package #:reblocks/doc/hooks)
 
 
@@ -37,7 +43,7 @@
                                   :reblocks/hooks))))
 
 
-(defmethod 40ants-doc/commondoc/builder:reference-to-commondoc
+(defmethod reference-to-commondoc
     ((symbol symbol)
      (locative-type (eql '40ants-doc/locatives::hook))
      locative-args)
@@ -51,11 +57,11 @@
            (get symbol :args))
          (children
            (when docstring
-             (40ants-doc/commondoc/markdown:parse-markdown docstring))))
-    (40ants-doc/commondoc/bullet:make-bullet reference
-                                             :arglist arglist
-                                             :children children
-                                             :ignore-words symbol)))
+             (parse-markdown docstring))))
+    (make-bullet reference
+                 :arglist arglist
+                 :children children
+                 :ignore-words symbol)))
 
 
 (defsection @hooks (:title "Hooks"

--- a/src/doc/intro.lisp
+++ b/src/doc/intro.lisp
@@ -10,6 +10,10 @@
 (defsection @intro (:title "Introduction"
                     :ignore-words ("ASDF"
                                    "API"
+                                   "HTTP"
+                                   "URL"
+                                   "HTTP"
+                                   "LAYER"
                                    "RSS"))
   "
 Reblocks is the fork of the Weblocks web frameworks written by Slava Akhmechet

--- a/src/utils/list.lisp
+++ b/src/utils/list.lisp
@@ -39,16 +39,32 @@
                    (intern (string-upcase (car i)) keyword-package))
        collect (cdr i))))
 
-(defun insert-after (newelt list index) 
+(declaim (inline %check-boundaries))
+(defun %check-boundaries (list index)
+  (let ((max-index (1- (length list))))
+    (when (or (< index 0)
+              (> index max-index))
+      (error "Index ~A is out of range [0:~A]"
+             index
+             max-index))))
+
+(declaim (inline %check-boundaries))
+(defun %insert-after-without-boundaries-check (newelt list index) 
   "Destructively inserts 'newelt' into 'list' after 'index'."
   (push newelt (cdr (nthcdr index list))) 
   list)
 
-(defmacro insert-at (newelt list index) 
+(defun insert-after (newelt list index) 
+  "Destructively inserts 'newelt' into 'list' after 'index'."
+  (%check-boundaries list index)
+  (%insert-after-without-boundaries-check newelt list index))
+
+(defun insert-at (newelt list index) 
   "Destructively inserts 'newelt' into 'list' before 'index'."
-  `(if (zerop ,index)
-       (push ,newelt ,list)
-       (insert-after ,newelt ,list (1- ,index))))
+  (%check-boundaries list index)
+  (if (zerop index)
+      (push newelt list)
+      (insert-after newelt list (1- index))))
 
 (defun ninsert (list thing pos)
     (if (zerop pos)


### PR DESCRIPTION
…wares list is generated for the server.

You might define your own REBLOCKS/SERVER:SERVER class and a method for REBLOCKS/SERVER:MAKE-MIDDLEWARES generic-function. Inside this method, you might inject additional middlewares using REBLOCKS/SERVER:INSERT-MIDDLEWARE function.

Also, a variable REBLOCKS/SERVER:*DEFAULT-SAMESITE-POLICY* was introdiced, to control default value of the SameSite HTTP header.

As a bonus, loading of reblocks-docs system was fixed.