### PR TITLE
Some changes from hackathon

### DIFF
--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,4 +5,4 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20230406120500"))
+  :version "20230527224500"))

--- a/src/actions.lisp
+++ b/src/actions.lisp
@@ -33,6 +33,8 @@
                 #:redirect)
   (:import-from #:reblocks/app-actions
                 #:get-action)
+  (:import-from #:serapeum
+                #:dict)
   
   (:export #:eval-action
            #:on-missing-action
@@ -208,14 +210,24 @@ situation (e.g. redirect, signal an error, etc.)."))
                  (quri:url-encode-params params))))
 
 
-(defun make-js-action (action)
+(defun make-js-action (action &key args)
   "Returns JS code which can be inserted into `onclick` attribute and will
    execute given Lisp function on click.
 
    It accepts any function as input and produces a string with JavaScript code."
+  (check-type args (or null hash-table))
+  
   (let* ((action-code (make-action action)))
-    (format nil "initiateAction(\"~A\"); return false;"
-            action-code)))
+    (cond
+      (args
+       (let ((options (dict "args" args)))
+         (format nil "initiateAction(\"~A\", ~A); return false;"
+                 action-code
+                 (yason:with-output-to-string* ()
+                   (yason:encode options)))))
+      (t
+       (format nil "initiateAction(\"~A\"); return false;"
+               action-code)))))
 
 
 (defun make-js-form-action (action)

--- a/src/actions.lisp
+++ b/src/actions.lisp
@@ -1,6 +1,7 @@
 (uiop:define-package #:reblocks/actions
   (:use #:cl)
   (:import-from #:log)
+  (:import-from #:yason)
   (:import-from #:reblocks/app
                 #:get-prefix
                 #:get-prefix-actions)

--- a/src/default-init.lisp
+++ b/src/default-init.lisp
@@ -33,6 +33,7 @@
         (:code
          (format nil "
 CL-USER> (defmethod reblocks/page:init-page ((app ~A) (url-path string) expire-at)
+           (check-type expire-at (or null local-time::timestamp))
            \"Hello world!\")" (string-downcase
                                (type-of *current-app*)))))
        (:p "And reset current session:")

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -32,6 +32,20 @@
                                                    "REBLOCKS/SESSION:INIT")
                                     :external-links (("Ultralisp" . "https://ultralisp.org"))
                                     :external-docs ("https://40ants.com/log4cl-extras/"))
+  (0.51.0 2023-05-27
+          """
+Changed
+=======
+
+* Function REBLOCKS/ACTIONS:MAKE-JS-ACTION now accepts ARGS argument. If given, it will be serialized as a dictionary and embedded into the action calling code. This way you can pass the arguments back into your lisp callback.
+
+Added
+=====
+
+* Added `includeCSS` and `includeJS` command handlers. This makes it possible to send such kind of commands via a websocket.
+* Now all widgets rendered on a page are collected into a hash table and you can find them by dom-id using REBLOCKS/PAGE:FIND-WIDGET-BY-ID function.
+
+""")
   (0.50.0 2022-12-03
           """
 Fixed

--- a/src/doc/page.lisp
+++ b/src/doc/page.lisp
@@ -3,6 +3,7 @@
   (:import-from #:40ants-doc
                 #:defsection)
   (:import-from #:reblocks/page
+                #:find-widget-by-id
                 #:page
                 #:init-page
                 #:on-page-refresh
@@ -89,6 +90,7 @@ then you should wrap all changing code in WITH-METADATA-LOCK macro.
   (current-page function)
   (get-page-by-id function)
   (in-page-context-p function)
+  (find-widget-by-id function)
   
   (ensure-page-metadata macro)
   (with-metadata-lock macro)

--- a/src/js/jquery/jquery.js
+++ b/src/js/jquery/jquery.js
@@ -244,7 +244,13 @@ window.commandHandlers = {
     },
     'executeCode': function(params) {
         jQuery(params.code).appendTo('body');
-    }
+    },
+    'includeCSS': function(params) {
+        include_css(params.url);
+    },
+    'includeJS': function(params) {
+        include_dom(params.url);
+    },
 };
 
 function processCommand(command) {
@@ -393,9 +399,7 @@ if(!window.XMLHttpRequest) {
 
 
 function include_css(css_file) {
-  libraryMissingWarning('include_css');
-
-  getStylesNotCached([css_file]);
+    appendStyleSheet(css_file);
 }
 
 function include_dom(script_filename) {

--- a/src/page-dependencies.lisp
+++ b/src/page-dependencies.lisp
@@ -55,6 +55,11 @@ Makes deduplication by comparing dependencies' urls."
   (cond
     ((in-page-context-p)
      (let* ((page (current-page)))
+       ;; TODO: this check makes hard to update
+       ;; css and js via websocket, because it
+       ;; prevents some files loading. I need
+       ;; to find a way how to disable this when
+       ;; hot CSS/JS reloading is enabled
        (unless (already-loaded-p page dependency)
          (push dependency (page-dependencies (current-page)))
          (pushnew dependency *page-dependencies*

--- a/src/page.lisp
+++ b/src/page.lisp
@@ -38,6 +38,7 @@
                 #:timestamp
                 #:now)
   (:import-from #:serapeum
+                #:dict
                 #:maybe-invoke-restart
                 #:fmt
                 #:take
@@ -61,6 +62,8 @@
                 #:make-uuid-from-string
                 #:uuid=
                 #:make-v4-uuid)
+  (:import-from #:reblocks/widgets/dom
+                #:dom-id)
   
   (:export
    #:render
@@ -88,7 +91,8 @@
    #:extend-expiration-time
    #:page-app
    #:with-metadata-lock
-   #:ensure-page-metadata))
+   #:ensure-page-metadata
+   #:find-widget-by-id))
 (in-package #:reblocks/page)
 
 
@@ -124,6 +128,8 @@
    (root-widget :initform nil
                 :initarg :root-widget
                 :accessor page-root-widget)
+   (id-to-widget :initform (dict)
+                 :reader id-to-widget)
    (app :initarg :app
         :initform *current-app*
         :accessor page-app)
@@ -593,3 +599,13 @@
 
                    Default method does nothing.")
   (:method ((from-page t) (to-url t))))
+
+
+(defun find-widget-by-id (widget-id)
+  (gethash widget-id (id-to-widget (current-page))))
+
+
+(defun register-widget (widget)
+  (setf (gethash (dom-id widget)
+                 (id-to-widget (current-page)))
+        widget))

--- a/src/page.lisp
+++ b/src/page.lisp
@@ -606,6 +606,7 @@
 
 
 (defun register-widget (widget)
-  (setf (gethash (dom-id widget)
-                 (id-to-widget (current-page)))
-        widget))
+  (when (in-page-context-p)
+    (setf (gethash (dom-id widget)
+                   (id-to-widget (current-page)))
+          widget)))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -385,7 +385,8 @@ If server is already started, then logs a warning and does nothing."
                    (server-type :hunchentoot)
                    (samesite-policy :lax)
                    apps
-                   (server-class 'server))
+                   (server-class 'server)
+                   (disable-welcome-app nil))
   "Starts reblocks framework hooked into Clack server.
 
    Set DEBUG to true in order for error messages and stack traces to be shown
@@ -393,7 +394,10 @@ If server is already started, then logs a warning and does nothing."
    in Hunchentoot 1.0.0).
 
    Server will start all apps declared having `autostart t` in their definition
-   unless APPS argument is provided."
+   unless APPS argument is provided.
+
+   Sometimes you might want your app respond on /some-uri and / return 404.
+   In this case it is useful to set DISABLE-WELCOME-APP argument to T."
 
   (ensure-pages-cleaner-is-running)
 
@@ -439,13 +443,14 @@ If server is already started, then logs a warning and does nothing."
               do (start-app server app-class))
 
         ;; If / prefix is not taken, start Welcome Screen app:
-        (loop with found-root = nil
-              for app in (apps server)
-              for prefix = (get-prefix app)
-              when (string= prefix "/")
-              do (setf found-root t)
-              finally (unless found-root
-                        (start-app server 'welcome-screen-app))))
+        (unless disable-welcome-app
+          (loop with found-root = nil
+                for app in (apps server)
+                for prefix = (get-prefix app)
+                when (string= prefix "/")
+                do (setf found-root t)
+                finally (unless found-root
+                          (start-app server 'welcome-screen-app)))))
       
       (values server))))
 

--- a/src/welcome/widget.lisp
+++ b/src/welcome/widget.lisp
@@ -14,7 +14,8 @@
   (:import-from #:reblocks/app
                 #:get-prefix
                 #:webapp-name
-                #:*current-app*))
+                #:*current-app*)
+  (:import-from #:local-time))
 (in-package #:reblocks/welcome/widget)
 
 
@@ -22,7 +23,9 @@
   ())
 
 
-(defmethod reblocks/page:init-page ((app welcome-screen-app) path expire-at)
+(defmethod reblocks/page:init-page ((app welcome-screen-app) url-path expire-at)
+  (check-type url-path (or null string))
+  (check-type expire-at (or null local-time:timestamp))
   (make-instance 'welcome-screen-widget))
 
 

--- a/src/widget.lisp
+++ b/src/widget.lisp
@@ -94,7 +94,7 @@ inherits from REBLOCKS/WIDGET:WIDGET if no DIRECT-SUPERCLASSES are provided."
   (:documentation "Returns a list of classes for the widget.
                    Classes may be a strings or a keywords.
                    By default, :widget and keyworded class name are returned.
-                   Use (append (list :new-class) (call-next-method))
+                   Use `(list* :new-class (call-next-method))`
                    to add new classes."))
 
 

--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -5,6 +5,8 @@
                 #:render-in-ajax-response)
   (:import-from #:reblocks/page-dependencies
                 #:push-dependencies)
+  (:import-from #:reblocks/page
+                #:register-widget)
   (:import-from #:reblocks/widget
                 #:get-css-classes-as-string
                 #:get-html-tag
@@ -40,6 +42,8 @@
   (let ((widget-dependencies (get-dependencies widget)))
     ;; Update new-style dependencies
     (push-dependencies widget-dependencies))
+
+  (register-widget widget)
   
   (with-html
     (:tag


### PR DESCRIPTION
Changed
=======

* Function REBLOCKS/ACTIONS:MAKE-JS-ACTION now accepts ARGS argument. If given, it will be serialized as a dictionary and embedded into the action calling code. This way you can pass the arguments back into your lisp callback.

Added
=====

* Added `includeCSS` and `includeJS` command handlers. This makes it possible to send such kind of commands via a websocket.
* Now all widgets rendered on a page are collected into a hash table and you can find them by dom-id using REBLOCKS/PAGE:FIND-WIDGET-BY-ID function.