### PR TITLE
Fixed commands ordering when processing widget UPDATE

### DIFF
--- a/reblocks-docs.asd
+++ b/reblocks-docs.asd
@@ -1,4 +1,4 @@
-(defsystem reblocks-docs
+(defsystem "reblocks-docs"
   :class :package-inferred-system
   :author "Alexander Artemenko"
   :licence "LLGPL"

--- a/reblocks.asd
+++ b/reblocks.asd
@@ -5,7 +5,7 @@
 ;;       (subseq line 0 space-pos))))
 
 
-(defsystem reblocks
+(defsystem "reblocks"
   :name "reblocks"
   :class :package-inferred-system
   ;; TODO: Take version from the src/doc/changelog.lisp

--- a/src/commands-hook.lisp
+++ b/src/commands-hook.lisp
@@ -4,11 +4,11 @@
                 #:on-application-hook-handle-http-request
                 #:call-next-hook)
   (:import-from #:reblocks/commands
-                #:*commands*))
+                #:with-collected-commands))
 (in-package #:reblocks/commands-hook)
 
 
 (on-application-hook-handle-http-request
-  reset-commands-list (env)
-  (let (*commands*)
+    reset-commands-list (env)
+  (with-collected-commands ()
     (call-next-hook)))

--- a/src/commands.lisp
+++ b/src/commands.lisp
@@ -3,7 +3,9 @@
   (:import-from #:alexandria)
   (:import-from #:parenscript)
   (:export #:add-command
-           #:get-collected-commands))
+           #:get-collected-commands
+           #:with-collected-commands
+           #:add-commands))
 (in-package #:reblocks/commands)
 
 
@@ -58,5 +60,8 @@
 
 
 (defmacro with-collected-commands (() &body body)
+  "Collects commands added using a call to ADD-COMMANDS during the body execution.
+
+   Commands list can be aquired using GET-COLLECTED-COMMANDS function."
   `(let (*commands*)
      ,@body))

--- a/src/commands.lisp
+++ b/src/commands.lisp
@@ -35,10 +35,18 @@
 (defun add-command (name &rest args)
   "Pushes a new command into the stack.
 
-After action processing these commands will be sent for execution on the client."
+   After action processing these commands will be sent for execution on the client."
   (push
    (apply #'create-command name args)
    *commands*))
+
+
+(defun add-commands (commands)
+  "Pushes all commands from the list into the stack.
+
+   After action processing these commands will be sent for execution on the client."
+  (loop for command in commands
+        do (push command *commands*)))
 
 
 (defun get-collected-commands ()
@@ -47,3 +55,8 @@ After action processing these commands will be sent for execution on the client.
   ;; we need to reverse it now.
   (reverse *commands*))
 
+
+
+(defmacro with-collected-commands (() &body body)
+  `(let (*commands*)
+     ,@body))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -32,7 +32,17 @@
                                                    "REBLOCKS/SESSION:INIT")
                                     :external-links (("Ultralisp" . "https://ultralisp.org"))
                                     :external-docs ("https://40ants.com/log4cl-extras/"))
-  (0.52.0 2025-06-08
+  (0.53.0 2023-06-20
+          """
+Changed
+=======
+
+Now all commands added using REBLOCKS/RESPONSE:SEND-SCRIPT or REBLOCKS/COMMANDS:ADD-COMMAND
+during the call to REBLOCKS/WIDGET:UPDATE generic-function, are added after the command
+for updating DOM node on the frontend. This fixes a problem happened when you attach
+some JS handlers to the DOM node, but after the update these handlers are deleted.
+""")
+  (0.52.0 2023-06-08
           """
 Added
 =====

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -13,6 +13,7 @@
                                                    "URL"
                                                    "URI"
                                                    "API"
+                                                   "DOM"
                                                    "AJAX"
                                                    "JSON"
                                                    "JSON-RPC"

--- a/src/doc/commands.lisp
+++ b/src/doc/commands.lisp
@@ -1,0 +1,40 @@
+(uiop:define-package #:reblocks/doc/commands
+  (:use #:cl)
+  (:import-from #:40ants-doc
+                #:defsection)
+  (:import-from #:named-readtables
+                #:in-readtable)
+  (:import-from #:pythonic-string-reader
+                #:pythonic-string-syntax)
+  (:import-from #:reblocks/commands
+                #:add-command
+                #:add-commands
+                #:get-collected-commands
+                #:with-collected-commands))
+(in-package #:reblocks/doc/commands)
+
+
+(in-readtable pythonic-string-syntax)
+
+
+(defsection @commands (:title "Commands"
+                       :ignore-words ("JS"
+                                      "CSS"
+                                      "AJAX"))
+  """
+  Commands are small pieces of information sent to the fronted for execution.
+  they are used to update widgets, to load JS or CSS code or to call some other functions
+  inside the frontend.
+
+  Right now this mechanism is not really useful because there is no a way to define
+  custom commands handler on the frontend. But in the future such facility may be added.
+  """
+  
+  (@commands-api section))
+
+
+(defsection @commands-api (:title "API")
+  (with-collected-commands macro)
+  (get-collected-commands function)
+  (add-command function)
+  (add-commands function))

--- a/src/doc/index.lisp
+++ b/src/doc/index.lisp
@@ -49,6 +49,8 @@
                 #:@request)
   (:import-from #:reblocks/doc/changelog
                 #:@changelog)
+  (:import-from #:reblocks/doc/commands
+                #:@commands)
   (:import-from #:reblocks/doc/debug
                 #:@debug)
   (:import-from #:docs-config
@@ -99,6 +101,7 @@
                            @page
                            @session
                            @debug
+                           @commands
                            @removed-features
                            @api
                            @contribute


### PR DESCRIPTION
Now all commands added using REBLOCKS/RESPONSE:SEND-SCRIPT or REBLOCKS/COMMANDS:ADD-COMMAND during the call to REBLOCKS/WIDGET:UPDATE generic-function, are added after the command for updating DOM node on the frontend. This fixes a problem happened when you attach some JS handlers to the DOM node, but after the update these handlers are deleted.