### PR TITLE
Add the option to specify attribute value pairs for get-html-tag.

### DIFF
--- a/src/utils/list.lisp
+++ b/src/utils/list.lisp
@@ -16,9 +16,7 @@
            #:ninsert
            #:find-all
            #:remove-keyword-parameter
-           #:remove-keyword-parameters
-	   #:safe-first
-	   #:safe-rest))
+           #:remove-keyword-parameters))
 (in-package #:reblocks/utils/list)
 
 
@@ -30,26 +28,6 @@
     (when (and end (> end length))
       (setf end length))
     (subseq sequence start end)))
-
-(defun safe-first (item)
-  "Returns first element of ITEM.
-There are two cases:
-- ITEM is a list, in which case it returns (first ITEM)
-- ITEM is not a list, in which case it retuns ITEM.
-The effect is the same as (first (alexandria:ensure-list item))"
-  (typecase item
-    (list (first item))
-    (t item)))
-
-(defun safe-rest (item)
-  "Returns rest of ITEM
-There are two cases:
-- ITEM is a list, in which case it returns (rest ITEM)
-- ITEM is not a list, in whch case it returns nil.
-The effect is the same as (rest (alexandria:ensure-list item))"
-  (typecase item
-    (list (rest item))
-    (t nil)))
 
 ;; TODO: replace with alexandria:alist-plist
 (defun alist->plist (alist)

--- a/src/utils/list.lisp
+++ b/src/utils/list.lisp
@@ -16,7 +16,9 @@
            #:ninsert
            #:find-all
            #:remove-keyword-parameter
-           #:remove-keyword-parameters))
+           #:remove-keyword-parameters
+	   #:safe-first
+	   #:safe-rest))
 (in-package #:reblocks/utils/list)
 
 
@@ -28,6 +30,26 @@
     (when (and end (> end length))
       (setf end length))
     (subseq sequence start end)))
+
+(defun safe-first (item)
+  "Returns first element of ITEM.
+There are two cases:
+- ITEM is a list, in which case it returns (first ITEM)
+- ITEM is not a list, in which case it retuns ITEM.
+The effect is the same as (first (alexandria:ensure-list item))"
+  (typecase item
+    (list (first item))
+    (t item)))
+
+(defun safe-rest (item)
+  "Returns rest of ITEM
+There are two cases:
+- ITEM is a list, in which case it returns (rest ITEM)
+- ITEM is not a list, in whch case it returns nil.
+The effect is the same as (rest (alexandria:ensure-list item))"
+  (typecase item
+    (list (rest item))
+    (t nil)))
 
 ;; TODO: replace with alexandria:alist-plist
 (defun alist->plist (alist)

--- a/src/widget.lisp
+++ b/src/widget.lisp
@@ -78,9 +78,28 @@ inherits from REBLOCKS/WIDGET:WIDGET if no DIRECT-SUPERCLASSES are provided."
 
 
 (defgeneric get-html-tag (widget)
-  (:documentation "This method should return a keyword, like :div or :article.
-                   By default, it returns :div.
-                   If we are inside a table, it returns :tr"))
+  (:documentation "This method determines the enclosing tag of the widget.
+The return value should either be a keyword like :div, which will be the enclosing tag,
+or a list of the form (:tag . attributes), where :tag is the enclosing tag (like :div)
+and attributes is a property list, where the keys are keywords, corresponding to the attribute name
+and the values are the values of the attribute.
+
+For example:
+
+- :div  -- generates a <div ...> WIDGET CONTENT </div>
+- (:div :display \"flex\") -- generates (<div ... :display \"flex\">WIDGET CONTENT</div>
+
+NOTE on attributes, in the attribute list the following attributes can
+not be specified, they will be ignored:
+
+- :class  -- Use the get-css-classes method to specify these
+- :id     -- This is the value of the dom-id slot of the widget,
+             normally automatically managed by reblocks.
+
+The default implementation returns
+- :td  -- inside a table row
+- :tr  -- inside a table
+- :div -- by default"))
 
 
 (defmethod get-html-tag ((widget t))

--- a/src/widget.lisp
+++ b/src/widget.lisp
@@ -92,10 +92,10 @@ For example:
 - :div  -- generates <div ...> widget content </div>
 - (:div :display \"flex\") -- generates (<div ... :display \"flex\">widget content</div>
 
-NOTE on attributes, in the attribute list the following attributes can
+Note on attributes: in the attribute list the following attributes can
 not be specified, they will be ignored:
 
-- :class  -- Use the GET-CSS-CLASSES method to specify these
+- :class  -- Use the get-css-classes method to specify these
 - :id     -- This is the value of the dom-id slot of the widget,
              normally automatically managed by reblocks.
 

--- a/src/widget.lisp
+++ b/src/widget.lisp
@@ -73,8 +73,8 @@ inherits from REBLOCKS/WIDGET:WIDGET if no DIRECT-SUPERCLASSES are provided."
                    You can use any other templating engine, just ensure
                    it writes output to REBLOCKS/HTML:*STREAM*
 
-                   Outer DIV wrapper will be added automaticall, see GET-HTML-TAG.
-                   It will have CSS tags returned by GET-CSS-CLASSES."))
+                   Outer DIV wrapper will be added automaticall, see GET-HTML-TAG generic-function.
+                   It will have CSS tags returned by GET-CSS-CLASSES generic-function."))
 
 
 (defgeneric get-html-tag (widget)
@@ -95,7 +95,7 @@ For example:
 Note on attributes: in the attribute list the following attributes can
 not be specified, they will be ignored:
 
-- :class  -- Use the get-css-classes method to specify these
+- :class  -- Use the GET-CSS-CLASSES generic-function to specify these
 - :id     -- This is the value of the dom-id slot of the widget,
              normally automatically managed by reblocks.
 

--- a/src/widget.lisp
+++ b/src/widget.lisp
@@ -73,26 +73,29 @@ inherits from REBLOCKS/WIDGET:WIDGET if no DIRECT-SUPERCLASSES are provided."
                    You can use any other templating engine, just ensure
                    it writes output to REBLOCKS/HTML:*STREAM*
 
-                   Outer DIV wrapper will be added automaticall. It will
-                   have CSS tags returned by GET-CSS-CLASSES."))
+                   Outer DIV wrapper will be added automaticall, see GET-HTML-TAG.
+                   It will have CSS tags returned by GET-CSS-CLASSES."))
 
 
 (defgeneric get-html-tag (widget)
   (:documentation "This method determines the enclosing tag of the widget.
-The return value should either be a keyword like :div, which will be the enclosing tag,
-or a list of the form (:tag . attributes), where :tag is the enclosing tag (like :div)
-and attributes is a property list, where the keys are keywords, corresponding to the attribute name
-and the values are the values of the attribute.
+
+The return value should either be a keyword like :div,
+which will be the enclosing tag, or a list of the form (:tag . attributes),
+where :tag is the enclosing tag (like :div) and attributes is a property list.
+
+The attributes property list has keywords for keys, corresponding to
+the attribute name and the values are the values of the attribute.
 
 For example:
 
-- :div  -- generates a <div ...> WIDGET CONTENT </div>
-- (:div :display \"flex\") -- generates (<div ... :display \"flex\">WIDGET CONTENT</div>
+- :div  -- generates <div ...> widget content </div>
+- (:div :display \"flex\") -- generates (<div ... :display \"flex\">widget content</div>
 
 NOTE on attributes, in the attribute list the following attributes can
 not be specified, they will be ignored:
 
-- :class  -- Use the get-css-classes method to specify these
+- :class  -- Use the GET-CSS-CLASSES method to specify these
 - :id     -- This is the value of the dom-id slot of the widget,
              normally automatically managed by reblocks.
 

--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -15,9 +15,8 @@
                 #:with-html)
   (:import-from #:reblocks/widgets/dom
                 #:dom-id)
-  (:import-from #:reblocks/utils/list
-		#:safe-first
-		#:safe-rest))
+  (:import-from #:uiop
+		#:ensure-list))
 (in-package #:reblocks/widgets/render-methods)
 
 
@@ -44,13 +43,15 @@
     (push-dependencies widget-dependencies))
 
   (register-widget widget)
-  
-  (with-html
-    (:tag
-     :name (safe-first (get-html-tag widget))
-     :class (get-css-classes-as-string widget)
-     :id (dom-id widget)
-     :attrs (safe-rest (get-html-tag widget))
-     (call-next-method))))
+
+  (destructuring-bind (tag-name . attributes)
+      (ensure-list (get-html-tag widget))
+    (with-html
+      (:tag
+       :name tag-name
+       :class (get-css-classes-as-string widget)
+       :id (dom-id widget)
+       :attrs attributes
+       (call-next-method)))))
 
 

--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -14,7 +14,10 @@
   (:import-from #:reblocks/html
                 #:with-html)
   (:import-from #:reblocks/widgets/dom
-                #:dom-id))
+                #:dom-id)
+  (:import-from #:reblocks/utils/list
+		#:safe-first
+		#:safe-rest))
 (in-package #:reblocks/widgets/render-methods)
 
 
@@ -44,9 +47,10 @@
   
   (with-html
     (:tag
-     :name (get-html-tag widget)
+     :name (safe-first (get-html-tag widget))
      :class (get-css-classes-as-string widget)
      :id (dom-id widget)
+     :attrs (safe-rest (get-html-tag widget))
      (call-next-method))))
 
 


### PR DESCRIPTION
This allows adding additional attribute value pairs to the enclosing tag of a widget.

Which is useful for adding attributes on widgets.   Most of the time it does not really matter, but especially with tables you cannot really add an inner <div> for a <tr> tag.

Another way of solving this is to add an additional method:  get-html-attributes.   

Just to reiterate the documentation string a bit:

get-html-tag now allows you to return a list like (:div :attribute-1 "value-1" :attrribute-2 "value-2" ...)
