### PR TITLE
Fix application of `*js-default-action*` format string in `make-js-action`.

### DIFF
--- a/src/actions.lisp
+++ b/src/actions.lisp
@@ -235,7 +235,7 @@ situation (e.g. redirect, signal an error, etc.)."))
                  (yason:with-output-to-string* ()
                    (yason:encode options)))))
       (t
-       (format nil *js-default-action* action-code)))))
+       (format nil *js-default-action* action-code nil)))))
 
 
 (defun make-js-form-action (action)


### PR DESCRIPTION
`format` needs correct number of arguments, even if some of those arguments might not even get rendered due to conditionals in the format string.

This fixes #64 .