### PR TITLE
A special method was added for Spinneret's `html` generic-function.

### DIFF
--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -35,6 +35,17 @@
                                                    "REBLOCKS/PAGE-DEPENDENCIES"
                                                    "REBLOCKS/SESSION:INIT")
                                     :external-links (("Ultralisp" . "https://ultralisp.org")))
+  (0.64.0 2025-05-22
+          "
+# Backward incompatible changes
+
+- Function REBLOCKS/UTILS/MISC:RELATIVE-PATH now accepts the pathnames and returns a pathname instead of string.
+
+# New
+
+- A special method was added for Spinneret's `html` generic-function. This method calls REBLOCKS/WIDGET:RENDER
+  generic-function if you use a widget in the body of Spinneret HTML tag.
+")
   (0.63.0 2025-05-17
           "
 - Class `reblocks/server::static-route-from-file` was renamed and now exported as REBLOCKS/ROUTES:STATIC-FILE-ROUTE along with

--- a/src/doc/rendering.lisp
+++ b/src/doc/rendering.lisp
@@ -14,18 +14,20 @@
 (in-readtable pythonic-string-syntax)
 
 
-(defsection @rendering (:title "Content Rendering")
+(defsection @rendering (:title "Content Rendering"
+                        :ignore-words ("HTML"
+                                       "DIV"
+                                       "CSS"
+                                       "JS"
+                                       "CL-WHO"
+                                       "UI"
+                                       "REBLOCKS-UI"))
   (@page section)
-  (@html section))
+  (@html section)
+  (@widgets section))
 
 
 (defsection @html (:title "HTML Rendering"
-                   :ignore-words ("HTML"
-                                  "DIV"
-                                  "CSS"
-                                  "CL-WHO"
-                                  "UI"
-                                  "REBLOCKS-UI")
                    :external-links (("Spinneret" . "https://github.com/ruricolist/spinneret")
                                     ("CL-WHO" . "https://edicl.github.io/cl-who/")
                                     ("REBLOCKS-UI" . "https://github.com/40ants/reblocks-ui")))
@@ -75,26 +77,63 @@ it writes output to the REBLOCKS/HTML:*STREAM* variable.
 
 For more advanced UI, look at the [REBLOCKS-UI][REBLOCKS-UI] documentation.
 
-## API
-  
-"""
-
-  ;; (reblocks/html:with-html macro)
-  ;; (reblocks/html:with-html-string macro)
-  ;; (reblocks/html:*stream* variable)
-  ;; (reblocks/html:*lang* variable)
-  ;; (reblocks/html:*pretty-html* variable)
+  """
 )
 
 
-(defsection @page (:title "Page Rendering"
-                   :ignore-words ("HTML"
-                                  "CSS"
-                                  "JS"))
-  ;; (reblocks/page:render generic-function)
-  ;; (reblocks/page:render-body generic-function)
-  ;; (reblocks/page:render-dependencies generic-function)
+(defsection @widgets (:title "Widget Rendering")
+  """
+  For rendering a widget content you have to define a method for REBLOCKS/WIDGET:RENDER generic-function.
+  Use REBLOCKS/HTML:WITH-HTML macro to write HTML using lisp expression. Under the hood, this macro
+  uses a great [Spinneret](https://github.com/ruricolist/spinneret) library:
+  
+  ```
+  (defwidget foo ()
+    ())
 
+
+  (defmethod reblocks/widget:render ((obj foo))
+    (reblocks/html:with-html ()
+      (:p "Hello world!")))
+
+  ```
+
+  Also, any string or object, returned from the render method, will be used
+  to render widget's content. For example, you might do:
+
+  ```
+  (defmethod reblocks/widget:render ((obj foo))
+    "<b>Hello</b> world!")
+  ```
+
+  But in this case, symbols `<` and `>` will be escaped and you will not see "Hello" in bold font.
+
+  If you don't want to use Spinneret for rendering but want to get HTML non-escaped, you need to write
+  HTML string into the REBLOCKS/HTML:*STREAM* stream like this:
+  Note, in this case we should explicitly say that our method does not return anything useful:
+
+  ```
+  (defmethod reblocks/widget:render ((obj foo))
+    (write-string "<b>Hello</b> world!"
+                  reblocks/html:*stream*
+                  )
+    (values))
+  ```
+
+  This will render "Hello" in bold as desired.
+
+  You can use this method for rendering some widgets using template engines other than Spinneret, such as:
+
+  - https://github.com/mmontone/djula
+  - https://github.com/kanru/cl-mustache
+  - https://github.com/moderninterpreters/markup
+
+  Just use engine you like and write it's output to REBLOCKS/HTML:*STREAM*!
+  
+  """)
+
+
+(defsection @page (:title "Page Rendering")
   """
   These functions can be used during rendering
   to retrieve an information about the page:
@@ -107,14 +146,13 @@ For more advanced UI, look at the [REBLOCKS-UI][REBLOCKS-UI] documentation.
   only after that renders page HTML headers.
   Thus you might use `setf` on these functions during
   widget rendering to change the title, description
-  or keywords.
-  """
-  ;; (reblocks/page:get-title function)
-  ;; (reblocks/page:get-description function)
-  ;; (reblocks/page:get-keywords function)
-  ;; (reblocks/page:get-language function)
+  or keywords:
+  
+  - REBLOCKS/PAGE:GET-TITLE
+  - REBLOCKS/PAGE:GET-DESCRIPTION
+  - REBLOCKS/PAGE:GET-KEYWORDS
+  - REBLOCKS/PAGE:GET-LANGUAGE
 
-  """
   If you want to change these variables globally for the whole
   application, then define a before method like this:
 

--- a/src/utils/misc.lisp
+++ b/src/utils/misc.lisp
@@ -13,6 +13,8 @@
   (:import-from #:closer-mop
                 #:funcallable-standard-object
                 #:required-args)
+  (:import-from #:serapeum
+                #:->)
   (:export #:safe-apply
            #:safe-funcall
            #:public-file-relative-path
@@ -178,16 +180,20 @@ answering its result."
   (merge-files file-list saved-path
                :linkage-element-fn (lambda (stream) (write-byte 10 stream))))
 
+
+(-> relative-path (pathname pathname)
+    (values pathname &optional))
+
 (defun relative-path (full-path prefix-path)
-  (princ-to-string
-   (make-pathname :directory (cons :relative
-                                   (nthcdr (length (pathname-directory prefix-path))
-                                           (pathname-directory full-path)))
-                  :name (pathname-name full-path)
-                  :type (pathname-type full-path))))
+  (make-pathname :directory (cons :relative
+                                  (nthcdr (length (pathname-directory prefix-path))
+                                          (pathname-directory full-path)))
+                 :name (pathname-name full-path)
+                 :type (pathname-type full-path)))
+
 
 (defun gzip-file (input output &key (if-exists #+ccl :overwrite #-ccl :supersede) (if-does-not-exist :create)
-                  (minimum-length 300))
+                                 (minimum-length 300))
   "Redefined salsa2:gzip-file with more keywords."
   (with-open-file (istream input :element-type '(unsigned-byte 8))
     (unless (< (file-length istream) minimum-length)

--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -55,3 +55,5 @@
        (call-next-method)))))
 
 
+(defmethod spinneret:html ((widget reblocks/widget:widget))
+  (render widget))

--- a/t/widgets/render-methods.lisp
+++ b/t/widgets/render-methods.lisp
@@ -67,6 +67,7 @@
         (render widget)))
      "<table><tr class=\"widget widget-inside-table\"><p>foo bar</tr></table>")))
 
+
 (deftest test-widget-tr-child
   (let ((widget (make-instance 'widget-inside-table)))
     (is-html
@@ -74,4 +75,14 @@
        (:table
         (:tr
          (render widget))))
+     "<table><tr><td class=\"widget widget-inside-table\"><p>foo bar</td></table>")))
+
+
+(deftest test-widget-tr-child-using-implicit-render
+  (let ((widget (make-instance 'widget-inside-table)))
+    (is-html
+     (with-html ()
+       (:table
+        (:tr
+         widget)))
      "<table><tr><td class=\"widget widget-inside-table\"><p>foo bar</td></table>")))


### PR DESCRIPTION
This method calls REBLOCKS/WIDGET:RENDER generic-function if you use a widget in the body of Spinneret HTML tag.