### PR TITLE
Fixed the `Unknown type of result: REBLOCKS/WIDGETS/STRING-WIDGET:STRING-WIDGET` error

### DIFF
--- a/src/app.lisp
+++ b/src/app.lisp
@@ -23,6 +23,8 @@
   (:import-from #:str
                 #:ensure-prefix
                 #:ensure-suffix)
+  (:import-from #:reblocks/routes
+                #:page)
   (:export #:defapp
            #:app
            #:get-autostarting-apps
@@ -153,7 +155,7 @@ called (primarily for backward compatibility"
                               :documentation))
          (routes (or
                   routes
-                  '((40ants-routes/defroutes:get ("/")
+                  '((page ("/")
                       (make-default-init-page-widget)))))
          (documentation (when documentation
                           (list (list :documentation documentation)))))

--- a/src/doc/changelog.lisp
+++ b/src/doc/changelog.lisp
@@ -35,6 +35,13 @@
                                                    "REBLOCKS/PAGE-DEPENDENCIES"
                                                    "REBLOCKS/SESSION:INIT")
                                     :external-links (("Ultralisp" . "https://ultralisp.org")))
+  (0.64.1 2025-05-27
+          "
+# Fixed
+
+* Fixed the `Unknown type of result: REBLOCKS/WIDGETS/STRING-WIDGET:STRING-WIDGET` error, occured in Reblocks applications initialized old-way by `init-page` method.
+
+  Thanks for the report to Mariano Montone!")
   (0.64.0 2025-05-22
           "
 # Backward incompatible changes


### PR DESCRIPTION
The error occured in Reblocks applications initialized old-way by `init-page` method.

Thanks for the report to Mariano Montone!

This should resolve issue https://github.com/40ants/reblocks/issues/80