### PR TITLE
Browser history control form server side

### DIFF
--- a/reblocks.asd
+++ b/reblocks.asd
@@ -25,6 +25,7 @@
                "reblocks/debug"
                "reblocks/default-init"
                "reblocks/commands-hook"
+               "reblocks/commands-history"
                "reblocks/widgets/string-widget"
                "reblocks/widgets/funcall-widget"
                "reblocks/welcome/widget"

--- a/src/commands-history.lisp
+++ b/src/commands-history.lisp
@@ -1,0 +1,40 @@
+(defpackage #:reblocks/commands/history
+  (:use #:cl)
+  (:import-from #:reblocks/actions
+                #:make-action)
+  (:import-from #:reblocks/commands
+                #:add-command)
+  (:export #:browser-history-push-state
+           #:browser-history-back
+           #:browser-history-forward))
+
+(in-package :reblocks/commands/history)
+
+(defun browser-history-push-state (url &key (state "{}")
+                                         pop-action)
+  "Invoke history.pushState on the client.
+
+See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
+  (let ((action-code (when pop-action
+                       (etypecase pop-action
+                         (string pop-action)
+                         (function (reblocks/actions:make-action pop-action))))))
+    (add-command :update-history
+                 :operation "pushState"
+                 :state state
+                 :url url
+                 :pop-action-code action-code)))
+
+(defun browser-history-forward ()
+  "Invoke history.forward() on the client.
+
+See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
+  (add-command :update-history
+               :operation "forward"))
+
+(defun browser-history-back ()
+  "Invoke history.back() on the client.
+
+See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
+  (add-command :update-history
+               :operation "back"))

--- a/src/commands.lisp
+++ b/src/commands.lisp
@@ -5,10 +5,7 @@
   (:export #:add-command
            #:get-collected-commands
            #:with-collected-commands
-           #:add-commands
-           #:browser-history-push-state
-           #:browser-history-back
-           #:browser-history-forward))
+           #:add-commands))
 
 (in-package #:reblocks/commands)
 
@@ -68,27 +65,3 @@
    Commands list can be aquired using GET-COLLECTED-COMMANDS function."
   `(let (*commands*)
      ,@body))
-
-(defun browser-history-push-state (url &optional (state "{}"))
-  "Invoke history.pushState on the client.
-
-See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
-
-  (add-command :update-history
-               :operation "pushState"
-               :state state
-               :url url))
-
-(defun browser-history-forward ()
-  "Invoke history.forward() on the client.
-
-See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
-  (add-command :update-history
-               :operation "forward"))
-
-(defun browser-history-back ()
-  "Invoke history.back() on the client.
-
-See: https://developer.mozilla.org/en-US/docs/Web/API/History_API"
-  (add-command :update-history
-               :operation "back"))

--- a/src/js/jquery/jquery.js
+++ b/src/js/jquery/jquery.js
@@ -241,7 +241,12 @@ window.commandHandlers = {
     'updateHistory' : function(params) {
         switch(params.operation) {
             case 'pushState':
-                history.pushState(JSON.parse(params.state), '', params.url);
+                let historyState = {
+                    //location: document.location,
+                    state: JSON.parse(params.state),
+                    popActionCode: params.popActionCode
+                };
+                history.pushState(historyState, '', params.url);
                 break;
             case 'back':
                 history.back();
@@ -252,6 +257,19 @@ window.commandHandlers = {
         }
     }
 };
+
+window.addEventListener("popstate", (event) => {
+    let historyState = event.state;
+    console.log(historyState);
+    if (historyState?.popActionCode) {
+        initiateAction(historyState.popActionCode, {
+            args: {
+                location: document.location,
+                state: JSON.stringify(historyState.state)
+            }
+        });
+    }
+});
 
 function processCommand(command) {
     var method = command.method;


### PR DESCRIPTION
This is to be able to control browser history from server side in ajax requests/components.

For example, I use this in an ajax pagination controller, to change the current page in the browser: `(history-push-state "?page=30")`